### PR TITLE
Add OSL config UI

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,154 @@
+module.exports = {
+  debounce: {
+    type: 'object',
+    order: 10,
+    properties: {
+      linter: {
+        type: 'integer',
+        title: 'Linter',
+        description:
+          'How long to idle (in milliseconds) after keypresses ' +
+          'before refreshing linter diagnostics. Smaller values refresh ' +
+          'diagnostics more quickly.',
+        default: 500,
+        order: 10,
+      },
+    },
+  },
+
+  diagnostics: {
+    type: 'object',
+    order: 20,
+    properties: {
+      tools: {
+        type: 'array',
+        title: 'Diagnostic tools',
+        description:
+          'Specifies which tool or tools will be used ' +
+          'to get diagnostics. Possible values are `merlin` and `bsb`. ' +
+          'If you choose both "merlin" and "bsb", merlin will be used ' +
+          'while editing and bsb when saving.',
+        items: {
+          type: 'string',
+          enum: ['merlin', 'bsb'],
+        },
+        default: ['merlin'],
+        order: 10,
+      },
+    },
+  },
+
+  format: {
+    type: 'object',
+    order: 30,
+    properties: {
+      width: {
+        type: ['null', 'integer'],
+        title: 'Line width',
+        description:
+          'Set the width of lines when formatting code with `refmt`. ' +
+          'Leave blank for default.',
+        default: null,
+        order: 10,
+      },
+    },
+  },
+
+  path: {
+    type: 'object',
+    order: 40,
+    properties: {
+      bsb: {
+        type: 'string',
+        title: 'bsb',
+        description: 'The path to the `bsb` binary.',
+        default: 'bsb',
+        order: 10,
+      },
+      env: {
+        type: 'string',
+        title: 'env',
+        description:
+          'The path to the `env` command which prints ' +
+          'the language server environment for debugging editor issues.',
+        default: 'env',
+        order: 20,
+      },
+      esy: {
+        type: 'string',
+        title: 'esy',
+        description: 'The path to the `esy` binary.',
+        default: 'esy',
+        order: 30,
+      },
+      ocamlfind: {
+        type: 'string',
+        title: 'ocamlfind',
+        description: 'The path to the `ocamlfind` binary.',
+        default: 'ocamlfind',
+        order: 40,
+      },
+      ocamlmerlin: {
+        type: 'string',
+        title: 'ocamlmerlin',
+        description: 'The path to the `ocamlmerlin` binary.',
+        default: 'ocamlmerlin',
+        order: 50,
+      },
+      opam: {
+        type: 'string',
+        title: 'opam',
+        description: 'The path to the `opam` binary.',
+        default: 'opam',
+        order: 60,
+      },
+      rebuild: {
+        type: 'string',
+        title: 'rebuild',
+        description: 'The path to the `rebuild` binary.',
+        default: 'rebuild',
+        order: 70,
+      },
+      refmt: {
+        type: 'string',
+        title: 'refmt',
+        description: 'The path to the `refmt` binary.',
+        default: 'refmt',
+        order: 80,
+      },
+      refmterr: {
+        type: 'string',
+        title: 'refmterr',
+        description: 'The path to the `refmterr` binary.',
+        default: 'refmterr',
+        order: 90,
+      },
+      rtop: {
+        type: 'string',
+        title: 'rtop',
+        description: 'The path to the `rtop` binary.',
+        default: 'rtop',
+        order: 100,
+      },
+    },
+  },
+
+  server: {
+    type: 'object',
+    order: 50,
+    properties: {
+      languages: {
+        type: 'array',
+        title: 'Server languages',
+        description:
+          'The list of languages enable support for in the language server.',
+        items: {
+          type: 'string',
+          enum: ['ocaml', 'reason'],
+        },
+        default: ['ocaml', 'reason'],
+        order: 10,
+      },
+    },
+  },
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,16 @@ const {AutoLanguageClient} = require('atom-languageclient')
 const atom = require('atom')
 const path = require('path')
 
-const scopes = [ 'source.reason', 'source.ocaml', 'source.re', 'source.ml', 'source.rei', 'source.mli' ]
+const config = require('./config')
+
+const scopes = [
+  'source.reason',
+  'source.ocaml',
+  'source.re',
+  'source.ml',
+  'source.rei',
+  'source.mli',
+]
 
 function flatten1(array) {
   return [].concat(...array)
@@ -35,6 +44,26 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
   getLanguageName () { return 'Reason' }
   getServerName () { return 'ocamlmerlin' }
   getConnectionType() { return 'ipc' }
+  getRootConfigurationKey() { return 'ide-reason' }
+
+  mapConfigurationObject(config) {
+    return {
+      reason: {
+        codelens: {
+          enabled: false,
+          unicode: true,
+        },
+        debounce: config.debounce,
+        diagnostics: {
+          tools: config.diagnostics.tools,
+          merlinPerfLogging: false,
+        },
+        format: config.format,
+        path: config.path,
+        server: config.server,
+      },
+    }
+  }
 
   activate() {
     super.activate()
@@ -46,7 +75,7 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
 
   startServerProcess (projectPath) {
     const serverPath = require.resolve('ocaml-language-server/bin/server')
-    return super.spawnChildNode([serverPath, '--node-ipc' ], {
+    return super.spawnChildNode([serverPath, '--node-ipc'], {
         stdio: [null, null, null, 'ipc'],
         pwd: projectPath,
         env: Object.assign({}, process.env, {
@@ -57,3 +86,5 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
 }
 
 module.exports = new ReasonMLLanguageClient()
+
+module.exports.config = config

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.7.3",
+    "atom-languageclient": "0.8.3",
     "atom-package-deps": "^4.6.1",
-    "ocaml-language-server": "1.0.25"
+    "ocaml-language-server": "1.0.27"
   },
   "package-deps": [
     "atom-ide-ui:0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,10 +8,11 @@ async@2.6.0:
   dependencies:
     lodash "^4.14.0"
 
-atom-languageclient@^0.7.3:
-  version "0.7.3"
-  resolved "http://registry.npm.taobao.org/atom-languageclient/download/atom-languageclient-0.7.3.tgz#4d5c859baab3f3394dc45129935b3037719542fb"
+atom-languageclient@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/atom-languageclient/-/atom-languageclient-0.8.3.tgz#8ce3c758051783a53a1d388896e7d99d4fc8e10c"
   dependencies:
+    fuzzaldrin-plus "^0.6.0"
     vscode-jsonrpc "^3.5.0"
 
 atom-package-deps@^4.6.1:
@@ -43,9 +44,17 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "http://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+deepmerge@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "http://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fuzzaldrin-plus@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz#832f6489fbe876769459599c914a670ec22947ee"
 
 glob@7.1.2:
   version "7.1.2"
@@ -91,11 +100,12 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-ocaml-language-server@1.0.25:
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/ocaml-language-server/-/ocaml-language-server-1.0.25.tgz#1b94aacab3a5418ed8edb4a4ce8de236af76b84b"
+ocaml-language-server@1.0.27:
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/ocaml-language-server/-/ocaml-language-server-1.0.27.tgz#b592579a9d2edce5e7064938f08b654ed2b64dfd"
   dependencies:
     async "2.6.0"
+    deepmerge "2.0.1"
     glob "7.1.2"
     lodash "4.17.5"
     lokijs "1.5.2"


### PR DESCRIPTION
This PR adds OSL configuration UI. Few issues to resolve.

**`bsb` integration**
One thing that doesn't work yet is `bsb` integration. Here's what I see w/ different `diagnostics.tools` config:

`["merlin"]`
Diagnostics is reported as I type. Errors persist after I hit Save.

`["merlin", "bsb"]`
Diagnostics is reported as I type. Errors disappear after I hit Save, `bsb` is not triggered.

`["bsb"]`
Nothing happens on change (as expected) and `bsb` is not triggered on save.

**Configurable toolchain**
This thing never worked b/c `readFileConf` always returns empty string (b/c `projectPath` is not passed). Anyway, w/ this change I don't think it makes sense to keep it as-is (even fixed). We can convert it into configuration file based on OSL configuration format and pick it from either `package.json` or `ide-reason.json`. Thoughts?