### PR TITLE
Replace spawn inexistent pwd option with cwd

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -48,7 +48,7 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
     const serverPath = require.resolve('ocaml-language-server/bin/server')
     return super.spawnChildNode([serverPath, '--node-ipc' ], {
         stdio: [null, null, null, 'ipc'],
-        pwd: projectPath,
+        cwd: projectPath,
         env: Object.assign({}, process.env, {
           PATH: joinEnvPath(extraPath, process.env.PATH)
         }),


### PR DESCRIPTION
As the title says. This fixes the issue @alexfedoseev was having with `bsb` in #11 (due to `bsb` trying to create the `/lib` folder in `/` and not having permissions to do so).