### PR TITLE
fix errors that makes ide-reason.json never work

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,16 +24,12 @@ function joinEnvPath(...paths) {
     .join(path.delimiter)
 }
 
-function readFileConf(file, property) {
+function readFileConf(projectPath, file, property) {
   try {
-    return require(path.join(projectPath, 'package.json'))[property] || ''
+    return require(path.join(projectPath, file))[property] || ''
   } catch (e) { }
   return ''
 }
-
-const pathFromPkg = readFileConf('package.json', 'reasonToolchainPath')
-const pathFromFile = readFileConf('ide-reason.json', 'toolchainPath')
-const extraPath = joinEnvPath(pathFromPkg, pathFromFile)
 
 class ReasonMLLanguageClient extends AutoLanguageClient {
   constructor(...props) {
@@ -74,6 +70,9 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
   }
 
   startServerProcess (projectPath) {
+    const pathFromPkg = readFileConf(projectPath, 'package.json', 'reasonToolchainPath')
+    const pathFromFile = readFileConf(projectPath, 'ide-reason.json', 'toolchainPath')
+    const extraPath = joinEnvPath(pathFromPkg, pathFromFile)
     const serverPath = require.resolve('ocaml-language-server/bin/server')
     return super.spawnChildNode([serverPath, '--node-ipc'], {
         stdio: [null, null, null, 'ipc'],


### PR DESCRIPTION
The readFileConf have to be called in startServerProcess since projectPath only available there