### PR TITLE
Compatibility with tree-sitter

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,10 +13,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
     result["default"] = mod;
     return result;
-}
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
-}
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const cp = __importStar(require("child_process"));
 const os = __importStar(require("os"));
@@ -36,6 +36,7 @@ const defaultConfig = deepmerge_1.default(languageServer.ISettings.defaults.reas
     },
 });
 const scopes = [
+    'ocaml',
     'source.reason',
     'source.ocaml',
     'source.re',
@@ -88,7 +89,7 @@ class ReasonMLLanguageClient extends atom_languageclient_1.AutoLanguageClient {
         }));
         this.subscriptions.add(atom.commands.add('atom-text-editor[data-grammar="source reason"]', {
             [`${pkg.name}:generate-interface`]: () => this.generateInterfaceFromEditor('re'),
-        }), atom.commands.add('atom-text-editor[data-grammar="source ocaml"]', {
+        }), atom.commands.add('atom-text-editor[data-grammar~="ocaml"]', {
             [`${pkg.name}:generate-interface`]: () => this.generateInterfaceFromEditor('ml'),
         }), atom.commands.add(".tree-view .file .name[data-name$=\\.re]", {
             [`${pkg.name}:generate-interface`]: event => this.generateInterfaceFromTreeView(event, 're'),

--- a/menus/atom-reasonml.json
+++ b/menus/atom-reasonml.json
@@ -6,7 +6,7 @@
         "command": "ide-reason:generate-interface"
       }
     ],
-    "atom-text-editor[data-grammar=\"source ocaml\"]": [
+    "atom-text-editor[data-grammar~=\"ocaml\"]": [
       {
         "label": "Generate OCaml interface",
         "command": "ide-reason:generate-interface"

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ const defaultConfig = merge<Config>(
 )
 
 const scopes = [
+  'ocaml',
   'source.reason',
   'source.ocaml',
   'source.re',
@@ -84,7 +85,7 @@ class ReasonMLLanguageClient extends AutoLanguageClient {
       atom.commands.add('atom-text-editor[data-grammar="source reason"]', {
         [`${pkg.name}:generate-interface`]: () => this.generateInterfaceFromEditor('re'),
       }),
-      atom.commands.add('atom-text-editor[data-grammar="source ocaml"]', {
+      atom.commands.add('atom-text-editor[data-grammar~="ocaml"]', {
         [`${pkg.name}:generate-interface`]: () => this.generateInterfaceFromEditor('ml'),
       }),
       atom.commands.add(".tree-view .file .name[data-name$=\\.re]", {


### PR DESCRIPTION
This PR adds the scope name `ocaml` to support the tree-sitter grammar.
Other ide packages are doing the same:
* rust-lang-nursery/atom-ide-rust#70
* lgeiger/ide-python#94
* atom/ide-typescript@8edda74987fbda205105a58b20ad1c9405474161