### PR TITLE
fix https://github.com/reasonml-editor/atom-ide-reason/issues/41

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -294,17 +294,20 @@ class ReasonMLLanguageClient extends atom_languageclient_1.AutoLanguageClient {
         return this.findRoot(location, ["bsconfig.json"]);
     }
     findRoot(location, test) {
-        const dirs = location.split(path.sep);
-        if (dirs.length === 0 || (dirs.length === 1 && dirs[0] === "")) {
+        const dir_obj=path.parse(location);
+        if (dir_obj.base === "") {
             return null;
         }
-        const file = path.join(...dirs, ...test);
+        const file = path.join(path.format(dir_obj), ...test);
         if (fs.existsSync(file)) {
             return location;
         }
         else {
-            let parent = path.join(...dirs.slice(0, -1));
-            return this.findRoot(parent[0] === path.sep ? parent : path.sep + parent, test);
+            let parent = path.format({
+                root: dir_obj.root,
+                dir: dir_obj.dir
+            });
+            return this.findRoot(parent, test);
         }
     }
     generateInterface(srcAbsPath, ext) {


### PR DESCRIPTION
Rewrote string manipulation to use `path`. Tested on same setup I discovered the issue with. 